### PR TITLE
Twisted build strategy 28

### DIFF
--- a/newsbuilder/__init__.py
+++ b/newsbuilder/__init__.py
@@ -8,7 +8,8 @@ L{newsbuilder} public APIs
 from ._newsbuilder import (
     findTwistedProjects, replaceInFile,
     replaceProjectVersion, Project, generateVersionFileData,
-    CommandFailed, runCommand, NewsBuilder, NotWorkingDirectory)
+    CommandFailed, runCommand, NewsBuilder, NotWorkingDirectory,
+    TwistedBuildStrategy)
 
 __all__ = [
     'findTwistedProjects',
@@ -20,6 +21,7 @@ __all__ = [
     'runCommand',
     'NewsBuilder',
     'NotWorkingDirectory',
+    'TwistedBuildStrategy',
     '__version__',
 ]
 

--- a/newsbuilder/_newsbuilder.py
+++ b/newsbuilder/_newsbuilder.py
@@ -511,15 +511,16 @@ class NewsBuilderScript(object):
     """
     The entry point for the I{newsbuilder} script.
     """
-    def __init__(self, newsBuilder=None, stdout=None, stderr=None):
+    def __init__(self, buildStrategy=None, newsBuilder=None,
+                 stdout=None, stderr=None):
         """
-        @param newsBuilder: A L{NewsBuilder} instance.
+        @param buildStrategy: A L{TwistedBuildStrategy} like instance.
         @param stdout: A file to which stdout messages will be written.
         @param stderr: A file to which stderr messages will be written.
         """
-        if newsBuilder is None:
-            newsBuilder = NewsBuilder()
-        self.newsBuilder = newsBuilder
+        if buildStrategy is None:
+            buildStrategy = TwistedBuildStrategy(newsBuilder=NewsBuilder())
+        self.buildStrategy = buildStrategy
 
         if stdout is None:
             stdout = sys.stdout
@@ -542,7 +543,7 @@ class NewsBuilderScript(object):
             self.stderr.write(message.encode('utf-8'))
             raise SystemExit(1)
 
-        self.newsBuilder.buildAll(options['repositoryPath'])
+        self.buildStrategy.buildAll(options['repositoryPath'])
 
 
 

--- a/newsbuilder/_newsbuilder.py
+++ b/newsbuilder/_newsbuilder.py
@@ -82,6 +82,49 @@ def _changeVersionInFile(old, new, filename):
 
 
 
+def _formatHeader(header):
+    """
+    Format a header for a NEWS file.
+
+    A header is a title with '=' signs underlining it.
+
+    @param header: The header string to format.
+    @type header: C{str}
+    @return: A C{str} containing C{header}.
+    """
+    return header + '\n' + '=' * len(header) + '\n\n'
+
+
+
+def _changeNewsVersion(news, name, oldVersion, newVersion, today):
+    """
+    Change all references to the current version number in a NEWS file to
+    refer to C{newVersion} instead.
+
+    @param news: The NEWS file to change.
+    @type news: L{FilePath}
+    @param name: The name of the project to change.
+    @type name: C{str}
+    @param oldVersion: The old version of the project.
+    @type oldVersion: L{Version}
+    @param newVersion: The new version of the project.
+    @type newVersion: L{Version}
+    @param today: A YYYY-MM-DD string representing today's date.
+    @type today: C{str}
+    """
+    newHeader = _formatHeader(
+        "Twisted %s %s (%s)" % (name, newVersion.base(), today))
+    expectedHeaderRegex = re.compile(
+        r"Twisted %s %s \(\d{4}-\d\d-\d\d\)\n=+\n\n" % (
+            re.escape(name), re.escape(oldVersion.base())))
+    oldNews = news.getContent()
+    match = expectedHeaderRegex.search(oldNews)
+    if match:
+        oldHeader = match.group()
+        replaceInFile(news.path, {oldHeader: newHeader})
+
+
+
 class Project(object):
     """
     A representation of a project that has a version.
@@ -279,19 +322,6 @@ class NewsBuilder(object):
         return results
 
 
-    def _formatHeader(self, header):
-        """
-        Format a header for a NEWS file.
-
-        A header is a title with '=' signs underlining it.
-
-        @param header: The header string to format.
-        @type header: C{str}
-        @return: A C{str} containing C{header}.
-        """
-        return header + '\n' + '=' * len(header) + '\n\n'
-
-
     def _writeHeader(self, fileObj, header):
         """
         Write a version header to the given file.
@@ -300,7 +330,7 @@ class NewsBuilder(object):
         @param header: The header to write to the file.
         @type header: C{str}
         """
-        fileObj.write(self._formatHeader(header))
+        fileObj.write(_formatHeader(header))
 
 
     def _writeSection(self, fileObj, header, tickets):
@@ -432,34 +462,6 @@ class NewsBuilder(object):
         if name == 'Twisted':
             name = 'Core'
         return name
-
-
-    def _changeNewsVersion(self, news, name, oldVersion, newVersion, today):
-        """
-        Change all references to the current version number in a NEWS file to
-        refer to C{newVersion} instead.
-
-        @param news: The NEWS file to change.
-        @type news: L{FilePath}
-        @param name: The name of the project to change.
-        @type name: C{str}
-        @param oldVersion: The old version of the project.
-        @type oldVersion: L{Version}
-        @param newVersion: The new version of the project.
-        @type newVersion: L{Version}
-        @param today: A YYYY-MM-DD string representing today's date.
-        @type today: C{str}
-        """
-        newHeader = self._formatHeader(
-            "Twisted %s %s (%s)" % (name, newVersion.base(), today))
-        expectedHeaderRegex = re.compile(
-            r"Twisted %s %s \(\d{4}-\d\d-\d\d\)\n=+\n\n" % (
-                re.escape(name), re.escape(oldVersion.base())))
-        oldNews = news.getContent()
-        match = expectedHeaderRegex.search(oldNews)
-        if match:
-            oldHeader = match.group()
-            replaceInFile(news.path, {oldHeader: newHeader})
 
 
 

--- a/newsbuilder/_newsbuilder.py
+++ b/newsbuilder/_newsbuilder.py
@@ -476,6 +476,13 @@ class NewsBuilderOptions(usage.Options):
     """
     Command line options for L{NewsBuilderScript}.
     """
+    synopsis = "Usage: newsbuilder [options] REPOSITORY_PATH"
+
+    longdesc = """\
+    REPOSITORY_PATH: The path to the root of your project.
+                     Must be a subversion repository.
+    """
+
     def __init__(self,  stdout=None, stderr=None):
         """
         @param stdout: A file to which stdout messages will be written.

--- a/newsbuilder/_newsbuilder.py
+++ b/newsbuilder/_newsbuilder.py
@@ -434,68 +434,6 @@ class NewsBuilder(object):
         return name
 
 
-    def _iterProjects(self, baseDirectory):
-        """
-        Iterate through the Twisted projects in C{baseDirectory}, yielding
-        everything we need to know to build news for them.
-
-        Yields C{topfiles}, C{name}, C{version}, for each sub-project in
-        reverse-alphabetical order. C{topfile} is the L{FilePath} for the
-        topfiles directory, C{name} is the nice name of the project (as should
-        appear in the NEWS file), C{version} is the current version string for
-        that project.
-
-        @param baseDirectory: A L{FilePath} representing the root directory
-            beneath which to find Twisted projects for which to generate
-            news (see L{findTwistedProjects}).
-        @type baseDirectory: L{FilePath}
-        """
-        # Get all the subprojects to generate news for
-        projects = findTwistedProjects(baseDirectory)
-        # And order them alphabetically for ease of reading
-        projects.sort(key=lambda proj: proj.directory.path)
-        # And generate them backwards since we write news by prepending to
-        # files.
-        projects.reverse()
-
-        for project in projects:
-            topfiles = project.directory.child("topfiles")
-            name = self._getNewsName(project)
-            version = project.getVersion()
-            yield topfiles, name, version
-
-
-    def buildAll(self, baseDirectory):
-        """
-        Find all of the Twisted subprojects beneath C{baseDirectory} and update
-        their news files from the ticket change description files in their
-        I{topfiles} directories and update the news file in C{baseDirectory}
-        with all of the news.
-
-        @param baseDirectory: A L{FilePath} representing the root directory
-            beneath which to find Twisted projects for which to generate
-            news (see L{findTwistedProjects}).
-        """
-        try:
-            runCommand(["svn", "info", baseDirectory.path])
-        except CommandFailed:
-            raise NotWorkingDirectory(
-                "%s does not appear to be an SVN working directory."
-                % (baseDirectory.path,))
-
-        today = self._today()
-        for topfiles, name, version in self._iterProjects(baseDirectory):
-            # We first build for the subproject
-            news = topfiles.child("NEWS")
-            header = "Twisted %s %s (%s)" % (name, version.base(), today)
-            self.build(topfiles, news, header)
-            # Then for the global NEWS file
-            news = baseDirectory.child("NEWS")
-            self.build(topfiles, news, header)
-            # Finally, delete the fragments
-            self._deleteFragments(topfiles)
-
-
     def _changeNewsVersion(self, news, name, oldVersion, newVersion, today):
         """
         Change all references to the current version number in a NEWS file to

--- a/newsbuilder/test/test_newsbuilder.py
+++ b/newsbuilder/test/test_newsbuilder.py
@@ -285,6 +285,20 @@ class UtilityTest(TestCase):
 
 
 
+def svnCommit(project, repository):
+    """
+    Make the C{project} directory a valid subversion directory with all
+    files committed to C{repository}.
+    """
+    runCommand(["svnadmin", "create", repository.path])
+    runCommand(["svn", "checkout", "file://" + repository.path,
+                project.path])
+
+    runCommand(["svn", "add"] + glob.glob(project.path + "/*"))
+    runCommand(["svn", "commit", project.path, "-m", "yay"])
+
+
+
 class NewsBuilderTests(TestCase, StructureAssertingMixin):
     """
     Tests for L{NewsBuilder}.
@@ -320,24 +334,6 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
                 '35.misc': '',
                 '40.doc': 'foo.bar.Baz.quux',
                 '41.doc': 'writing Foo servers'})
-
-
-    def svnCommit(self, project=None):
-        """
-        Make the C{project} directory a valid subversion directory with all
-        files committed.
-        """
-        if project is None:
-            project = self.project
-        repositoryPath = self.mktemp()
-        repository = FilePath(repositoryPath)
-
-        runCommand(["svnadmin", "create", repository.path])
-        runCommand(["svn", "checkout", "file://" + repository.path,
-                    project.path])
-
-        runCommand(["svn", "add"] + glob.glob(project.path + "/*"))
-        runCommand(["svn", "commit", project.path, "-m", "yay"])
 
 
     def test_today(self):
@@ -714,7 +710,7 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
         builder._today = lambda: '2009-12-01'
 
         project = self.createFakeTwistedProject()
-        self.svnCommit(project)
+        svnCommit(project, repository=FilePath(self.mktemp()))
         builder.buildAll(project)
 
         coreTopfiles = project.child("topfiles")
@@ -742,7 +738,7 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
         """
         builder = NewsBuilder()
         project = self.createFakeTwistedProject()
-        self.svnCommit(project)
+        svnCommit(project, repository=FilePath(self.mktemp()))
         builder.buildAll(project)
 
         aggregateNews = project.child("NEWS")
@@ -761,7 +757,7 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
         builder = NewsBuilder()
         builder._today = lambda: '2009-12-01'
         project = self.createFakeTwistedProject()
-        self.svnCommit(project)
+        svnCommit(project, repository=FilePath(self.mktemp()))
         builder.buildAll(project)
         newVersion = Version('TEMPLATE', 7, 7, 14)
         coreNews = project.child('topfiles').child('NEWS')
@@ -791,7 +787,7 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
         """
         builder = NewsBuilder()
         project = self.createFakeTwistedProject()
-        self.svnCommit(project)
+        svnCommit(project, repository=FilePath(self.mktemp()))
         builder.buildAll(project)
 
         self.assertEqual(5, len(project.children()))

--- a/newsbuilder/test/test_newsbuilder.py
+++ b/newsbuilder/test/test_newsbuilder.py
@@ -268,7 +268,6 @@ class UtilityTest(TestCase):
         self.assertEqual(cwd, os.getcwd())
 
 
-
     def test_replaceInFile(self):
         """
         L{replaceInFile} replaces data in a file based on a dict. A key from

--- a/newsbuilder/test/test_newsbuilder.py
+++ b/newsbuilder/test/test_newsbuilder.py
@@ -30,7 +30,7 @@ from newsbuilder import (
     runCommand, NewsBuilder, NotWorkingDirectory, TwistedBuildStrategy,
     NewsBuilderOptions, NewsBuilderScript, __version__)
 
-from newsbuilder._newsbuilder import _changeNewsVersion
+from newsbuilder._newsbuilder import _changeNewsVersion, _formatHeader
 
 if os.name != 'posix':
     skip = "Release toolchain only supported on POSIX."
@@ -289,6 +289,13 @@ class UtilityTest(TestCase):
         replaceInFile('release.replace', {'2.0.0': '3.0.0'})
         self.assertEqual(open('release.replace').read(), expected)
 
+
+    def test_formatHeader(self):
+        """
+        L{_formatHeader} accepts a title and underlines it with I{=} followed by
+        newlines.
+        """
+        self.assertEqual('Foo\n===\n\n', _formatHeader('Foo'))
 
 
     def test_changeVersionInNews(self):

--- a/newsbuilder/test/test_newsbuilder.py
+++ b/newsbuilder/test/test_newsbuilder.py
@@ -301,6 +301,29 @@ def svnCommit(project, repository):
 
 
 
+def createFakeTwistedProject(project):
+    """
+    Create a fake-looking Twisted project to build from.
+    """
+    project = project.child("twisted")
+    project.makedirs()
+    createStructure(
+        project, {
+            'NEWS': 'Old boring stuff from the past.\n',
+            '_version.py': genVersion("twisted", 1, 2, 3),
+            'topfiles': {
+                'NEWS': 'Old core news.\n',
+                '3.feature': 'Third feature addition.\n',
+                '5.misc': ''},
+            'conch': {
+                '_version.py': genVersion("twisted.conch", 3, 4, 5),
+                'topfiles': {
+                    'NEWS': 'Old conch news.\n',
+                    '7.bugfix': 'Fixed that bug.\n'}}})
+    return project
+
+
+
 class NewsBuilderTests(TestCase, StructureAssertingMixin):
     """
     Tests for L{NewsBuilder}.
@@ -674,28 +697,6 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
             'Here is stuff which was present previously.\n')
 
 
-    def createFakeTwistedProject(self):
-        """
-        Create a fake-looking Twisted project to build from.
-        """
-        project = FilePath(self.mktemp()).child("twisted")
-        project.makedirs()
-        createStructure(
-            project, {
-                'NEWS': 'Old boring stuff from the past.\n',
-                '_version.py': genVersion("twisted", 1, 2, 3),
-                'topfiles': {
-                    'NEWS': 'Old core news.\n',
-                    '3.feature': 'Third feature addition.\n',
-                    '5.misc': ''},
-                'conch': {
-                    '_version.py': genVersion("twisted.conch", 3, 4, 5),
-                    'topfiles': {
-                        'NEWS': 'Old conch news.\n',
-                        '7.bugfix': 'Fixed that bug.\n'}}})
-        return project
-
-
     def test_buildAll(self):
         """
         L{NewsBuilder.buildAll} calls L{NewsBuilder.build} once for each
@@ -711,7 +712,7 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
             path, output, header))
         builder._today = lambda: '2009-12-01'
 
-        project = self.createFakeTwistedProject()
+        project = createFakeTwistedProject(FilePath(self.mktemp()))
         svnCommit(project, repository=FilePath(self.mktemp()))
         builder.buildAll(project)
 
@@ -739,7 +740,7 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
         files, only deleting fragments once it's done.
         """
         builder = NewsBuilder()
-        project = self.createFakeTwistedProject()
+        project = createFakeTwistedProject(FilePath(self.mktemp()))
         svnCommit(project, repository=FilePath(self.mktemp()))
         builder.buildAll(project)
 
@@ -758,7 +759,7 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
         """
         builder = NewsBuilder()
         builder._today = lambda: '2009-12-01'
-        project = self.createFakeTwistedProject()
+        project = createFakeTwistedProject(FilePath(self.mktemp()))
         svnCommit(project, repository=FilePath(self.mktemp()))
         builder.buildAll(project)
         newVersion = Version('TEMPLATE', 7, 7, 14)
@@ -788,7 +789,7 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
         process, using the C{svn} C{rm} command.
         """
         builder = NewsBuilder()
-        project = self.createFakeTwistedProject()
+        project = createFakeTwistedProject(FilePath(self.mktemp()))
         svnCommit(project, repository=FilePath(self.mktemp()))
         builder.buildAll(project)
 

--- a/newsbuilder/test/test_newsbuilder.py
+++ b/newsbuilder/test/test_newsbuilder.py
@@ -699,61 +699,6 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
             'Here is stuff which was present previously.\n')
 
 
-    def test_buildAll(self):
-        """
-        L{NewsBuilder.buildAll} calls L{NewsBuilder.build} once for each
-        subproject, passing that subproject's I{topfiles} directory as C{path},
-        the I{NEWS} file in that directory as C{output}, and the subproject's
-        name as C{header}, and then again for each subproject with the
-        top-level I{NEWS} file for C{output}. Blacklisted subprojects are
-        skipped.
-        """
-        builds = []
-        builder = NewsBuilder()
-        builder.build = lambda path, output, header: builds.append((
-            path, output, header))
-        builder._today = lambda: '2009-12-01'
-
-        project = createFakeTwistedProject(FilePath(self.mktemp()))
-        svnCommit(project, repository=FilePath(self.mktemp()))
-        builder.buildAll(project)
-
-        coreTopfiles = project.child("topfiles")
-        coreNews = coreTopfiles.child("NEWS")
-        coreHeader = "Twisted Core 1.2.3 (2009-12-01)"
-
-        conchTopfiles = project.child("conch").child("topfiles")
-        conchNews = conchTopfiles.child("NEWS")
-        conchHeader = "Twisted Conch 3.4.5 (2009-12-01)"
-
-        aggregateNews = project.child("NEWS")
-
-        self.assertEqual(
-            builds,
-            [(conchTopfiles, conchNews, conchHeader),
-             (conchTopfiles, aggregateNews, conchHeader),
-             (coreTopfiles, coreNews, coreHeader),
-             (coreTopfiles, aggregateNews, coreHeader)])
-
-
-    def test_buildAllAggregate(self):
-        """
-        L{NewsBuilder.buildAll} aggregates I{NEWS} information into the top
-        files, only deleting fragments once it's done.
-        """
-        builder = NewsBuilder()
-        project = createFakeTwistedProject(FilePath(self.mktemp()))
-        svnCommit(project, repository=FilePath(self.mktemp()))
-        builder.buildAll(project)
-
-        aggregateNews = project.child("NEWS")
-
-        aggregateContent = aggregateNews.getContent()
-        self.assertIn("Third feature addition", aggregateContent)
-        self.assertIn("Fixed that bug", aggregateContent)
-        self.assertIn("Old boring stuff from the past", aggregateContent)
-
-
     def test_changeVersionInNews(self):
         """
         L{NewsBuilder._changeVersions} gets the release date for a given
@@ -783,32 +728,6 @@ class NewsBuilderTests(TestCase, StructureAssertingMixin):
             ' - #5\n\n\n')
         self.assertEqual(
             expectedCore + 'Old core news.\n', coreNews.getContent())
-
-
-    def test_removeNEWSfragments(self):
-        """
-        L{NewsBuilder.buildALL} removes all the NEWS fragments after the build
-        process, using the C{svn} C{rm} command.
-        """
-        builder = NewsBuilder()
-        project = createFakeTwistedProject(FilePath(self.mktemp()))
-        svnCommit(project, repository=FilePath(self.mktemp()))
-        builder.buildAll(project)
-
-        self.assertEqual(5, len(project.children()))
-        output = runCommand(["svn", "status", project.path])
-        removed = [line for line in output.splitlines()
-                   if line.startswith("D ")]
-        self.assertEqual(3, len(removed))
-
-
-    def test_checkSVN(self):
-        """
-        L{NewsBuilder.buildAll} raises L{NotWorkingDirectory} when the given
-        path is not a SVN checkout.
-        """
-        self.assertRaises(
-            NotWorkingDirectory, self.builder.buildAll, self.project)
 
 
 

--- a/newsbuilder/test/test_newsbuilder.py
+++ b/newsbuilder/test/test_newsbuilder.py
@@ -833,25 +833,6 @@ class TwistedBuildStrategyTests(TestCase):
 
 
 
-class FakeNewsBuilder(object):
-    """
-    A fake L{NewsBuilder} which records the arguments passed to its methods.
-    """
-    def __init__(self):
-        """
-        Initialise lists for recording method calls.
-        """
-        self.buildAllCalls = []
-
-
-    def buildAll(self, baseDirectory):
-        """
-        Record calls to L{NewsBuilder.buildAll}.
-        """
-        self.buildAllCalls.append(baseDirectory)
-
-
-
 class NewsBuilderOptionsTests(TestCase):
     """
     Tests for L{NewsBuilderOptions}.
@@ -864,6 +845,26 @@ class NewsBuilderOptionsTests(TestCase):
         options = NewsBuilderOptions()
         options.parseOptions([expectedPath])
         self.assertEqual(FilePath(expectedPath), options['repositoryPath'])
+
+
+
+class FakeBuildStrategy(object):
+    """
+    A fake L{TwistedBuildStrategy} which records the arguments passed to its
+    methods.
+    """
+    def __init__(self):
+        """
+        Initialise lists for recording method calls.
+        """
+        self.buildAllCalls = []
+
+
+    def buildAll(self, baseDirectory):
+        """
+        Record calls to L{buildAll}.
+        """
+        self.buildAllCalls.append(baseDirectory)
 
 
 
@@ -892,7 +893,7 @@ class NewsBuilderScriptTests(TestCase):
 
     def test_argsTooFew(self):
         """
-        L{BuildNewsScript.main} raises L{SystemExit} when less than 1 argument
+        L{NewsBuilderScript.main} raises L{SystemExit} when less than 1 argument
         is passed to it and writes a message to stderr.
         """
         stderr = io.BytesIO()
@@ -906,7 +907,7 @@ class NewsBuilderScriptTests(TestCase):
 
     def test_argsTooMany(self):
         """
-        L{BuildNewsScript.main} raises L{SystemExit} when more than 1 argument
+        L{NewsBuilderScript.main} raises L{SystemExit} when more than 1 argument
         is passed to it and writes a message to stderr.
         """
         stderr = io.BytesIO()
@@ -920,14 +921,14 @@ class NewsBuilderScriptTests(TestCase):
 
     def test_mainCallsBuildAll(self):
         """
-        L{BuildNewsScript.main} calls C{self.newsBuilder.buildAll} with the
+        L{NewsBuilderScript.main} calls C{self.buildStrategy.buildAll} with the
         supplied repository directory path.
         """
         expectedPath = b'/foo/bar/baz'
-        fakeNewsBuilder = FakeNewsBuilder()
-        script = NewsBuilderScript(newsBuilder=fakeNewsBuilder)
+        fakeBuildStrategy = FakeBuildStrategy()
+        script = NewsBuilderScript(buildStrategy=fakeBuildStrategy)
         script.main([expectedPath])
         self.assertEqual(
             [FilePath(expectedPath)],
-            fakeNewsBuilder.buildAllCalls
+            fakeBuildStrategy.buildAllCalls
         )


### PR DESCRIPTION
I've moved a lot of stuff around in this branch with the aim of identifying which parts are Twisted specific and being able to use newsbuilder for Twisted releases.
- Moved Twisted specific build rules into a new `TwistedBuildStrategy` class which then calls `NewsBuilder.build`. Later I intend to write a simpler default BuildStrategy which doesn't attempt to detect versions and doesn't assume that the project lives in a subversion repo.
- Moved various helper functions out of `NewsBuilder` to the module level where they can be re-used more easily or eventually deleted if they turn out to be Twisted specific.
- Added a synopsis and longdesc to the newsbuilder command (which I forgot to do in #30)

Hopefully all this will make it easier to use newsbuilder for Twisted releases. There's a twisted branch where you can see how it will be used:
- https://twistedmatrix.com/trac/log/branches/newsbuilder-7524

Fixes #28
